### PR TITLE
Arith rr: modulo eliminations

### DIFF
--- a/src/preprocessing/passes/learned_rewrite.cpp
+++ b/src/preprocessing/passes/learned_rewrite.cpp
@@ -293,6 +293,65 @@ Node LearnedRewrite::rewriteLearned(Node nr,
         }
       }
     }
+    Kind den_k = den.getKind();
+    // pow2(e) positive for e >= 0.
+    if (den_k == Kind::POW2) {
+        Node exp = den[0];
+        arith::Bounds exp_db = binfer.get(exp);
+        if (!exp_db.lower_value.isNull() 
+        && exp_db.lower_value.getConst<Rational>().sgn() == 1) {
+          isNonZeroDen = true;
+        }
+    } else if (den_k == Kind::NONLINEAR_MULT || den_k == Kind::INTS_DIVISION ||
+               den_k == Kind::ADD || den_k == Kind::SUB)
+    {
+      Node arg1 = den[0];
+      Node arg2 = den[1];
+      arith::Bounds arg1_db = binfer.get(arg1);
+      arith::Bounds arg2_db = binfer.get(arg2);
+
+      bool arg1_pos = false, arg1_neg = false, arg2_pos = false, arg2_neg = false;
+      if (!arg1_db.lower_value.isNull()) {
+          Rational arg1_low = arg1_db.lower_value.getConst<Rational>();
+          arg1_pos = (arg1_low.sgn() > 0);
+      }
+      if (!arg1_db.upper_value.isNull()) {
+          Rational arg1_up = arg1_db.upper_value.getConst<Rational>();
+          arg1_neg = (arg1_up.sgn() < 0);
+      }
+      if (!arg2_db.lower_value.isNull()) {
+          Rational arg2_low = arg2_db.lower_value.getConst<Rational>();
+          arg2_pos = (arg2_low.sgn() > 0);
+      }
+      if (!arg2_db.upper_value.isNull()) {
+          Rational arg2_up = arg2_db.upper_value.getConst<Rational>();
+          arg2_neg = (arg2_up.sgn() < 0);
+      }
+
+      // --- Case 1: Multiplication or division ---
+      // The denominator is nonzero if both operands are strictly positive or strictly negative.
+      if ((den_k == Kind::NONLINEAR_MULT || den_k == Kind::INTS_DIVISION) &&
+          ( (arg1_pos || arg1_neg) && (arg2_pos || arg2_neg) ))
+      {
+        isNonZeroDen = true;
+      }
+
+      // --- Case 2: Addition ---
+      // The sum is nonzero if both operands are strictly positive or strictly negative.
+      else if (den_k == Kind::ADD)
+      {
+      if ((arg1_pos && arg2_pos) || (arg1_neg && arg2_neg))
+        isNonZeroDen = true;;
+      }
+
+      // --- Case 3: Subtraction ---
+      // The result is nonzero if the operands have different signs.
+      else if (den_k == Kind::SUB)
+      {
+        if ((arg1_pos && arg2_neg) || (arg1_neg && arg2_pos))
+              isNonZeroDen = true;
+      }
+    }
     if (isNonZeroDen)
     {
       Trace("learned-rewrite-rr-debug")

--- a/src/preprocessing/passes/learned_rewrite.cpp
+++ b/src/preprocessing/passes/learned_rewrite.cpp
@@ -296,60 +296,51 @@ Node LearnedRewrite::rewriteLearned(Node nr,
     Kind den_k = den.getKind();
     // pow2(e) positive for e >= 0.
     if (den_k == Kind::POW2) {
-        Node exp = den[0];
-        arith::Bounds exp_db = binfer.get(exp);
-        if (!exp_db.lower_value.isNull() 
-        && exp_db.lower_value.getConst<Rational>().sgn() == 1) {
-          isNonZeroDen = true;
-        }
-    } else if (den_k == Kind::NONLINEAR_MULT || den_k == Kind::INTS_DIVISION ||
-               den_k == Kind::ADD || den_k == Kind::SUB)
-    {
+      Node exp = den[0];
+      arith::Bounds exp_db = binfer.get(exp);
+      if (!exp_db.lower_value.isNull() &&
+          exp_db.lower_value.getConst<Rational>().sgn() == 1) {
+        isNonZeroDen = true;
+      }
+    } else if (den_k == Kind::NONLINEAR_MULT || den_k == Kind::ADD ||
+               den_k == Kind::SUB) {
       Node arg1 = den[0];
       Node arg2 = den[1];
       arith::Bounds arg1_db = binfer.get(arg1);
       arith::Bounds arg2_db = binfer.get(arg2);
 
-      bool arg1_pos = false, arg1_neg = false, arg2_pos = false, arg2_neg = false;
+      bool arg1_pos = false, arg1_neg = false, arg2_pos = false,
+           arg2_neg = false;
       if (!arg1_db.lower_value.isNull()) {
-          Rational arg1_low = arg1_db.lower_value.getConst<Rational>();
-          arg1_pos = (arg1_low.sgn() > 0);
+        Rational arg1_low = arg1_db.lower_value.getConst<Rational>();
+        arg1_pos = (arg1_low.sgn() > 0);
       }
       if (!arg1_db.upper_value.isNull()) {
-          Rational arg1_up = arg1_db.upper_value.getConst<Rational>();
-          arg1_neg = (arg1_up.sgn() < 0);
+        Rational arg1_up = arg1_db.upper_value.getConst<Rational>();
+        arg1_neg = (arg1_up.sgn() < 0);
       }
       if (!arg2_db.lower_value.isNull()) {
-          Rational arg2_low = arg2_db.lower_value.getConst<Rational>();
-          arg2_pos = (arg2_low.sgn() > 0);
+        Rational arg2_low = arg2_db.lower_value.getConst<Rational>();
+        arg2_pos = (arg2_low.sgn() > 0);
       }
       if (!arg2_db.upper_value.isNull()) {
-          Rational arg2_up = arg2_db.upper_value.getConst<Rational>();
-          arg2_neg = (arg2_up.sgn() < 0);
+        Rational arg2_up = arg2_db.upper_value.getConst<Rational>();
+        arg2_neg = (arg2_up.sgn() < 0);
       }
 
-      // --- Case 1: Multiplication or division ---
-      // The denominator is nonzero if both operands are strictly positive or strictly negative.
-      if ((den_k == Kind::NONLINEAR_MULT || den_k == Kind::INTS_DIVISION) &&
-          ( (arg1_pos || arg1_neg) && (arg2_pos || arg2_neg) ))
-      {
+      // Multiplication: The denominator is nonzero if both operands are
+      // strictly positive or strictly negative.
+      if ((den_k == Kind::NONLINEAR_MULT) &&
+          ((arg1_pos || arg1_neg) && (arg2_pos || arg2_neg))) {
         isNonZeroDen = true;
       }
 
-      // --- Case 2: Addition ---
-      // The sum is nonzero if both operands are strictly positive or strictly negative.
-      else if (den_k == Kind::ADD)
-      {
-      if ((arg1_pos && arg2_pos) || (arg1_neg && arg2_neg))
-        isNonZeroDen = true;;
-      }
-
-      // --- Case 3: Subtraction ---
-      // The result is nonzero if the operands have different signs.
-      else if (den_k == Kind::SUB)
-      {
-        if ((arg1_pos && arg2_neg) || (arg1_neg && arg2_pos))
-              isNonZeroDen = true;
+      // Addition: The sum is nonzero if both operands are strictly positive or
+      // strictly negative.
+      else if (den_k == Kind::ADD) {
+        if ((arg1_pos && arg2_pos) || (arg1_neg && arg2_neg))
+          isNonZeroDen = true;
+        ;
       }
     }
     if (isNonZeroDen)

--- a/src/preprocessing/passes/learned_rewrite.cpp
+++ b/src/preprocessing/passes/learned_rewrite.cpp
@@ -302,8 +302,8 @@ Node LearnedRewrite::rewriteLearned(Node nr,
           exp_db.lower_value.getConst<Rational>().sgn() == 1) {
         isNonZeroDen = true;
       }
-    } else if (den_k == Kind::NONLINEAR_MULT || den_k == Kind::ADD ||
-               den_k == Kind::SUB) {
+    } else if (den_k == Kind::NONLINEAR_MULT || den_k == Kind::ADD) {
+      // Rules for nonzero binary operators
       Node arg1 = den[0];
       Node arg2 = den[1];
       arith::Bounds arg1_db = binfer.get(arg1);

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -15,6 +15,7 @@
 
 # Regression level 0 tests
 set(regress_0_tests
+
   regress0/arith/ackermann.real.smt2
   regress0/arith/arith-eq.smt2
   regress0/arith/arith-min-max-static-learn.smt2
@@ -1152,8 +1153,14 @@ set(regress_0_tests
   regress0/nl/issue9661.smt2
   regress0/nl/lazard-spurious-root.smt2
   regress0/nl/magnitude-wrong-1020-m.smt2
+  regress0/nl/mod_elim_add.smt2
+  regress0/nl/mod_elim_mul.smt2
+  regress0/nl/mod_elim_neg_add.smt2
+  regress0/nl/mod_elim_neg_mul.smt2
+  regress0/nl/mod_elim_pos_neg_mul.smt2
+  regress0/nl/mod_elim_pow2.smt2
   regress0/nl/mult-po.smt2
-  regress0/nl/nia-wrong-tl.smt2
+  regress0/nl/nia-wrong-tl.smt2s
   regress0/nl/nlExtPurify-test.smt2
   regress0/nl/nta/cos-sig-value.smt2
   regress0/nl/nta/dd.mirko_example_01.k5.bound300.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -15,7 +15,6 @@
 
 # Regression level 0 tests
 set(regress_0_tests
-
   regress0/arith/ackermann.real.smt2
   regress0/arith/arith-eq.smt2
   regress0/arith/arith-min-max-static-learn.smt2

--- a/test/regress/cli/CMakeLists.txt
+++ b/test/regress/cli/CMakeLists.txt
@@ -1160,7 +1160,7 @@ set(regress_0_tests
   regress0/nl/mod_elim_pos_neg_mul.smt2
   regress0/nl/mod_elim_pow2.smt2
   regress0/nl/mult-po.smt2
-  regress0/nl/nia-wrong-tl.smt2s
+  regress0/nl/nia-wrong-tl.smt2
   regress0/nl/nlExtPurify-test.smt2
   regress0/nl/nta/cos-sig-value.smt2
   regress0/nl/nta/dd.mirko_example_01.k5.bound300.smt2

--- a/test/regress/cli/regress0/nl/mod_elim_add.smt2
+++ b/test/regress/cli/regress0/nl/mod_elim_add.smt2
@@ -1,0 +1,16 @@
+; COMMAND-LINE: --learned-rewrite
+; EXPECT: unsat
+; DISABLE-TESTER: unsat-core
+; DISABLE-TESTER: proof
+(set-logic QF_NIA)
+(declare-const A Int)
+(declare-const B Int)
+(declare-const C Int)
+(declare-const D Int)
+(define-fun lemma () Bool (= (mod (+ (mod A (+ C D)) B) (+ C D)) (mod (+ A B) (+ C D))))
+
+(assert (> C 0))
+(assert (> D 0))
+
+(assert (not lemma))
+(check-sat)

--- a/test/regress/cli/regress0/nl/mod_elim_mul.smt2
+++ b/test/regress/cli/regress0/nl/mod_elim_mul.smt2
@@ -1,0 +1,16 @@
+; COMMAND-LINE: --learned-rewrite
+; EXPECT: unsat
+; DISABLE-TESTER: unsat-core
+; DISABLE-TESTER: proof
+(set-logic QF_NIA)
+(declare-const A Int)
+(declare-const B Int)
+(declare-const C Int)
+(declare-const D Int)
+(define-fun lemma () Bool (= (mod (+ (mod A (* C D)) B) (* C D)) (mod (+ A B) (* C D))))
+
+(assert (> C 0))
+(assert (> D 0))
+
+(assert (not lemma))
+(check-sat)

--- a/test/regress/cli/regress0/nl/mod_elim_neg_add.smt2
+++ b/test/regress/cli/regress0/nl/mod_elim_neg_add.smt2
@@ -1,0 +1,16 @@
+; COMMAND-LINE: --learned-rewrite
+; EXPECT: unsat
+; DISABLE-TESTER: unsat-core
+; DISABLE-TESTER: proof
+(set-logic QF_NIA)
+(declare-const A Int)
+(declare-const B Int)
+(declare-const C Int)
+(declare-const D Int)
+(define-fun lemma () Bool (= (mod (+ (mod A (+ C D)) B) (+ C D)) (mod (+ A B) (+ C D))))
+
+(assert (< C 0))
+(assert (< D 0))
+
+(assert (not lemma))
+(check-sat)

--- a/test/regress/cli/regress0/nl/mod_elim_neg_mul.smt2
+++ b/test/regress/cli/regress0/nl/mod_elim_neg_mul.smt2
@@ -1,0 +1,16 @@
+; COMMAND-LINE: --learned-rewrite
+; EXPECT: unsat
+; DISABLE-TESTER: unsat-core
+; DISABLE-TESTER: proof
+(set-logic QF_NIA)
+(declare-const A Int)
+(declare-const B Int)
+(declare-const C Int)
+(declare-const D Int)
+(define-fun lemma () Bool (= (mod (+ (mod A (* C D)) B) (* C D)) (mod (+ A B) (* C D))))
+
+(assert (< C 0))
+(assert (< D 0))
+
+(assert (not lemma))
+(check-sat)

--- a/test/regress/cli/regress0/nl/mod_elim_pos_neg_mul.smt2
+++ b/test/regress/cli/regress0/nl/mod_elim_pos_neg_mul.smt2
@@ -1,0 +1,16 @@
+; COMMAND-LINE: --learned-rewrite
+; EXPECT: unsat
+; DISABLE-TESTER: unsat-core
+; DISABLE-TESTER: proof
+(set-logic QF_NIA)
+(declare-const A Int)
+(declare-const B Int)
+(declare-const C Int)
+(declare-const D Int)
+(define-fun lemma () Bool (= (mod (+ (mod A (* C D)) B) (* C D)) (mod (+ A B) (* C D))))
+
+(assert (< C 0))
+(assert (> D 0))
+
+(assert (not lemma))
+(check-sat)

--- a/test/regress/cli/regress0/nl/mod_elim_pow2.smt2
+++ b/test/regress/cli/regress0/nl/mod_elim_pow2.smt2
@@ -1,0 +1,14 @@
+; COMMAND-LINE: --learned-rewrite
+; EXPECT: unsat
+; DISABLE-TESTER: unsat-core
+; DISABLE-TESTER: proof
+(set-logic QF_NIA)
+(declare-const A Int)
+(declare-const B Int)
+(declare-const C Int)
+(define-fun lemma () Bool (= (mod (+ (mod A (int.pow2 C)) B) (int.pow2 C)) (mod (+ A B) (int.pow2 C))))
+
+(assert (> C 0))
+
+(assert (not lemma))
+(check-sat)


### PR DESCRIPTION
Adds modulo elimination when the second operand is positive.
This rewriting idea is based on the paper “Bit-precise Reasoning with Parametric Bit-vectors.”