### PR TITLE
Pow2 Monotonicity Lemma

### DIFF
--- a/src/theory/arith/nl/pow2_solver.cpp
+++ b/src/theory/arith/nl/pow2_solver.cpp
@@ -135,7 +135,7 @@ void Pow2Solver::checkFullRefine()
 
     Integer x = valXConcrete.getConst<Rational>().getNumerator();
     Integer pow2x = valPow2xAbstract.getConst<Rational>().getNumerator();
-    // add monotinicity lemmas
+    // add monotinicity lemmas: 0 <= x < y -> pow2(x) * 2 <= pow2(y)
     for (uint64_t j = i + 1; j < size; j++)
     {
       Node m = d_pow2s[j];
@@ -145,22 +145,23 @@ void Pow2Solver::checkFullRefine()
       Integer y = valYConcrete.getConst<Rational>().getNumerator();
       Integer pow2y = valPow2yAbstract.getConst<Rational>().getNumerator();
 
-      if (x >= 0 && x < y && pow2x >= pow2y)
+      if (x >= 0 && x < y &&  pow2y < pow2x + pow2x)
       {
-        // 0 <= x /\ x < y => pow2(x) < pow2(y)
         Node x_lt_y = nm->mkNode(Kind::LT, n[0], m[0]);
         Node xgeq0 = nm->mkNode(Kind::LEQ, d_zero, n[0]);
         Node assumption = nm->mkNode(Kind::AND, xgeq0, x_lt_y);
-        Node conclusion = nm->mkNode(Kind::LT, n, m);
+        Node x_times_2 = nm->mkNode(Kind::ADD, n, n);
+        Node conclusion = nm->mkNode(Kind::LEQ, x_times_2, m);
         Node lem = nm->mkNode(Kind::IMPLIES, assumption, conclusion);
         d_im.addPendingLemma(
             lem, InferenceId::ARITH_NL_POW2_MONOTONE_REFINE, nullptr, true);
-      }
-      else if (y <= 0 && y < x && pow2x <= pow2y)
+      } else if (y < x &&  pow2x < pow2y + pow2y)
       {
-        // 0 <= y /\ y < x => pow2(y) < pow2(x)
-        Node assumption = nm->mkNode(Kind::LT, m[0], n[0]);
-        Node conclusion = nm->mkNode(Kind::LT, m, n);
+        Node y_lt_x = nm->mkNode(Kind::LT, m[0], n[0]);
+        Node ygeq0 = nm->mkNode(Kind::LEQ, d_zero, m[0]);
+        Node assumption = nm->mkNode(Kind::AND, ygeq0, y_lt_x);
+        Node y_times_2 = nm->mkNode(Kind::ADD, m, m);
+        Node conclusion = nm->mkNode(Kind::LEQ, y_times_2, n);
         Node lem = nm->mkNode(Kind::IMPLIES, assumption, conclusion);
         d_im.addPendingLemma(
             lem, InferenceId::ARITH_NL_POW2_MONOTONE_REFINE, nullptr, true);


### PR DESCRIPTION
improved pow2 monotonicity lemma.
I ran the benchmarks on QF_NIA and QF_UFNIA with a 60-second timeout. The results show an overall improvement in solved instances and a reduction in timeouts.
 config                               status  total       solved   sat     unsat  best  timeout  memout  error  uniq  dis  time_cpu    memory
 pow2_new_monotinicity  ok        13443    7344      3651   3693  4361     5955       0      0    32    0  363989.1  404316.5
 pow2_old_monotinicity   ok        13443    7338       3650   3688  5100     5965       0      0    26    0  364456.9  408097.6

There are several benchmarks that the new lemma solves in less than a second, which the old lemma fails to solve within the one-minute timeout, for examples:
syrew/terms_bvurem-213.smt2 
syrew/terms_bvurem-126.smt2
rewrite/terms_size3/test-pbv1316.smt2.
rewrite/terms_size3/test-pbv1378.smt2
mut/alive_mutant/alive-sat-bvnot-to-bvneg/Select_741_values_0.smt2
